### PR TITLE
Comment out ServiceLocator.Instance.Add<IOBDDevice, OBDDeviceSim>(); and add missing interface

### DIFF
--- a/OBDLibrary/ObdLibiOS/ObdWrapper.cs
+++ b/OBDLibrary/ObdLibiOS/ObdWrapper.cs
@@ -84,7 +84,29 @@ namespace ObdLibiOS
             else
                 return false;
         }
-
+        public Dictionary<string, string> Read()
+        {
+            if (!this._simulatormode && this._socket == null)
+            {
+                //if there is no connection
+                return null;
+            }
+            var ret = new Dictionary<string, string>();
+            lock (_lock)
+            {
+                foreach (var key in _data.Keys)
+                {
+                    ret.Add(key, _data[key]);
+                }
+                _data["spd"] = DefValue;  //Speed
+                _data["bp"] = DefValue;   //BarometricPressure
+                _data["rpm"] = DefValue;  //RPM
+                _data["ot"] = DefValue;   //OutsideTemperature
+                _data["it"] = DefValue;   //InsideTemperature
+                _data["efr"] = DefValue;  //EngineFuelRate
+            }
+            return ret;
+        }
         private async void PollObd()
         {
             try
@@ -343,7 +365,7 @@ namespace ObdLibiOS
             System.Diagnostics.Debug.WriteLine(s);
             return s;
         }
-        public void Disconnect()
+        public async Task Disconnect()
         {
             _running = false;
             if(_stream != null)

--- a/XamarinApp/MyTrips/MyTrips.iOS/AppDelegate.cs
+++ b/XamarinApp/MyTrips/MyTrips.iOS/AppDelegate.cs
@@ -32,7 +32,7 @@ namespace MyTrips.iOS
             
             //TODO: Need to add #debug compile dir for all offline\mock interfaces
             ServiceLocator.Instance.Add<IOBDDevice, OBDDevice>();
-            ServiceLocator.Instance.Add<IOBDDevice, OBDDeviceSim>();
+            //ServiceLocator.Instance.Add<IOBDDevice, OBDDeviceSim>();
 
             Xamarin.Insights.Initialize(Logger.InsightsKey);
 			


### PR DESCRIPTION
Comment out ServiceLocator.Instance.Add<IOBDDevice, OBDDeviceSim>();
add missing interface of IOBDDevice in obd ios
