### PR TITLE
Fix bug: Xamarin App: OBD Wrapper is causing hang in app due to endle…

### DIFF
--- a/OBDLibrary/ObdLibAndroid/ObdWrapper.cs
+++ b/OBDLibrary/ObdLibAndroid/ObdWrapper.cs
@@ -169,7 +169,7 @@ namespace ObdLibAndroid
                                 _data[key] = s;
                             }
                         if (!this._running)
-                            break;
+                            return;
                     }
                 }
             }

--- a/OBDLibrary/ObdLibUWP/ObdWrapper.cs
+++ b/OBDLibrary/ObdLibUWP/ObdWrapper.cs
@@ -155,9 +155,9 @@ namespace ObdLibUWP
                                 _data[key] = s;
                             }
                         if (!this._running)
-                            break;
+                            return;
                         await Task.Delay(Interval);
-                    }                    
+                    }
                 }
             }
             catch (System.Exception ex)

--- a/OBDLibrary/ObdLibiOS/ObdWrapper.cs
+++ b/OBDLibrary/ObdLibiOS/ObdWrapper.cs
@@ -133,7 +133,7 @@ namespace ObdLibiOS
                                 _data[key] = s;
                             }
                         if (!this._running)
-                            break;
+                            return;
                         await Task.Delay(Interval);
                     }
                 }


### PR DESCRIPTION
…ss loop in PollObd after Disconnect is called
