### PR TITLE
Updating to 2015 C++ Runtime.

### DIFF
--- a/src/MobileApps/MyDriving/MyDriving.UWP/MyDriving.UWP.csproj
+++ b/src/MobileApps/MyDriving/MyDriving.UWP/MyDriving.UWP.csproj
@@ -406,8 +406,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="Microsoft.VCLibs.120, Version=14.0">
-      <Name>Microsoft Visual C++ 2013 Runtime Package for Windows Universal</Name>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
     <SDKReference Include="SQLite.UWP.2015, Version=3.11.1">
       <Name>SQLite for Universal Windows Platform</Name>


### PR DESCRIPTION
Updating to 2015 C++ Runtime. We believe this is causing the HockeyApp integration crash. I have tested this locally on the app and once the build  comes out will test with HockeyApp. 
