### PR TITLE
Workaround for .NET native MissingInteropDataException . 

### DIFF
--- a/src/MobileApps/MyDriving/MyDriving.UWP/MyDriving.UWP.csproj
+++ b/src/MobileApps/MyDriving/MyDriving.UWP/MyDriving.UWP.csproj
@@ -40,7 +40,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>
@@ -63,7 +63,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -86,7 +86,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'XTC|x86'">
     <OutputPath>bin\x86\XTC\</OutputPath>

--- a/src/MobileApps/MyDriving/MyDriving.UWP/Properties/Default.rd.xml
+++ b/src/MobileApps/MyDriving/MyDriving.UWP/Properties/Default.rd.xml
@@ -23,6 +23,7 @@
     -->
     <Assembly Name="*Application*" Dynamic="Required All" />
     
+    <Type Name="System.Collections.Generic.List{Windows.Devices.Geolocation.BasicGeoposition}" MarshalObject="Required All"/>
     
     <!-- Add your application specific runtime directives here. -->
 


### PR DESCRIPTION
This is an issue in VS Update 1. .NET native was not generating interop data for list of BasicGeoposition which throws an exception. The workaround is to tell it to generate it forcefully. Also enabled .NET native compilation. 
