### PR TITLE
Fixing the regression caused due to moving to splitviewshell.

### DIFF
--- a/src/MobileApps/MyDriving/MyDriving.UWP/Views/CurrentTripView.xaml.cs
+++ b/src/MobileApps/MyDriving/MyDriving.UWP/Views/CurrentTripView.xaml.cs
@@ -221,7 +221,7 @@ namespace MyDriving.UWP.Views
 
         private async void SessionRevoked(object sender, ExtendedExecutionRevokedEventArgs args)
         {
-            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
             {
                 switch (args.Reason)
                 {
@@ -235,6 +235,7 @@ namespace MyDriving.UWP.Views
                 }
 
                 ClearExtendedExecution();
+                await BeginExtendedExecution();
             });
         }
        


### PR DESCRIPTION
After changing he OnLaunched logic now we no longer are creating CurrentTripView everytime we revoke. So it makes sense to start an extended session as soon as we revoke. This way the app is running in the background collecting data. 
