### PR TITLE
fix-518 store to VIN shorter message if parsing failed

### DIFF
--- a/src/OBDLibrary/ObdShare/ObdUtil.cs
+++ b/src/OBDLibrary/ObdShare/ObdUtil.cs
@@ -110,7 +110,7 @@ namespace ObdShare
             }
             catch (Exception exp)
             {
-                return exp.Message;
+                return "PARSING FAILED";
             }
         }
 


### PR DESCRIPTION
fixing https://github.com/Azure-Samples/MyDriving/issues/518
storing to vin shorter message if parsing fails