### PR TITLE
Issue #548: MyDriving app needs to handle expired/invalid access tokens for authentication

### DIFF
--- a/src/MobileApps/MyDriving/MyDriving.Android/Helpers/Authentication.cs
+++ b/src/MobileApps/MyDriving/MyDriving.Android/Helpers/Authentication.cs
@@ -3,28 +3,30 @@
 
 using System;
 using MyDriving.Utils;
+using MyDriving.Utils.Interfaces;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.MobileServices;
-using MyDriving.Interfaces;
 using Plugin.CurrentActivity;
 
 namespace MyDriving.Droid.Helpers
 {
     public class Authentication : IAuthentication
     {
-        public async Task<MobileServiceUser> LoginAsync(IMobileServiceClient client,
-            MobileServiceAuthenticationProvider provider)
+        public async Task<MobileServiceUser> LoginAsync(IMobileServiceClient client, MobileServiceAuthenticationProvider provider)
         {
+            MobileServiceUser user = null;
+            
             try
             {
                 Settings.Current.LoginAttempts++;
-                var user = await client.LoginAsync(CrossCurrentActivity.Current.Activity, provider);
+
+                user = await client.LoginAsync(CrossCurrentActivity.Current.Activity, provider);
                 Settings.Current.AuthToken = user?.MobileServiceAuthenticationToken ?? string.Empty;
                 Settings.Current.AzureMobileUserId = user?.UserId ?? string.Empty;
-                return user;
             }
             catch (Exception e)
             {
+                //Don't log if the user cancelled out of the login screen
                 if (!e.Message.Contains("cancelled"))
                 {
                     e.Data["method"] = "LoginAsync";
@@ -32,7 +34,7 @@ namespace MyDriving.Droid.Helpers
                 }
             }
 
-            return null;
+            return user;
         }
 
         public void ClearCookies()

--- a/src/MobileApps/MyDriving/MyDriving.Android/MainApplication.cs
+++ b/src/MobileApps/MyDriving/MyDriving.Android/MainApplication.cs
@@ -7,6 +7,7 @@ using Android.OS;
 using Android.Runtime;
 using Plugin.CurrentActivity;
 using MyDriving.Utils;
+using MyDriving.Utils.Interfaces;
 using MyDriving.Interfaces;
 using MyDriving.Droid.Helpers;
 using Acr.UserDialogs;

--- a/src/MobileApps/MyDriving/MyDriving.AzureClient/AzureClient.cs
+++ b/src/MobileApps/MyDriving/MyDriving.AzureClient/AzureClient.cs
@@ -2,6 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Microsoft.WindowsAzure.MobileServices;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MyDriving.Utils;
+using Newtonsoft.Json.Linq;
+using System;
 
 namespace MyDriving.AzureClient
 {
@@ -9,9 +14,8 @@ namespace MyDriving.AzureClient
     {
         const string DefaultMobileServiceUrl = "https://mydriving.azurewebsites.net";
         static IMobileServiceClient client;
-      
-        public IMobileServiceClient Client => client ?? (client = CreateClient());
 
+        public IMobileServiceClient Client => client ?? (client = CreateClient());
 
         IMobileServiceClient CreateClient()
         {
@@ -24,6 +28,17 @@ namespace MyDriving.AzureClient
                 }
             };
             return client;
+        }
+
+        public static async Task CheckIsAuthTokenValid()
+        {
+            //Check if the access token is valid by sending a general request to mobile service
+            var client = ServiceLocator.Instance.Resolve<IAzureClient>()?.Client;
+            try
+            {
+                await client.InvokeApiAsync("/.auth/me", HttpMethod.Get, null);
+            }
+            catch { } //Eat any exceptions
         }
     }
 }

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Abstractions/IBaseStore.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Abstractions/IBaseStore.cs
@@ -17,7 +17,6 @@ namespace MyDriving.DataStore.Abstractions
         Task<bool> RemoveAsync(T item);
         Task<bool> RemoveItemsAsync(IEnumerable<T> items);
         Task<bool> SyncAsync();
-        Task<bool> PullLatestAsync();
         Task<bool> DropTable();
     }
 }

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/StoreManager.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/StoreManager.cs
@@ -11,6 +11,9 @@ using MyDriving.DataObjects;
 using System.Collections.Generic;
 using System.Linq;
 using MyDriving.AzureClient;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Threading;
 
 namespace MyDriving.DataStore.Azure
 {
@@ -48,7 +51,7 @@ namespace MyDriving.DataStore.Azure
             store.DefineTable<POI>();
             store.DefineTable<IOTHubData>();
 
-            await client.SyncContext.InitializeAsync(store, new MobileServiceSyncHandler()).ConfigureAwait(false);
+            await client.SyncContext.InitializeAsync(store, new MobileServiceSyncHandler());
 
             IsInitialized = true;
         }
@@ -60,7 +63,7 @@ namespace MyDriving.DataStore.Azure
 
             var taskList = new List<Task<bool>> {TripStore.SyncAsync()};
 
-            var successes = await Task.WhenAll(taskList).ConfigureAwait(false);
+            var successes = await Task.WhenAll(taskList);
             return successes.Any(x => !x); //if any were a failure.
         }
 

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/BaseStore.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/BaseStore.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using MyDriving.DataObjects;
 using Plugin.Connectivity;
 using MyDriving.AzureClient;
+using MyDriving.Utils.Interfaces;
 
 namespace MyDriving.DataStore.Azure.Stores
 {
@@ -44,49 +45,47 @@ namespace MyDriving.DataStore.Azure.Stores
             return result;
         }
 
-
         public async Task InitializeStoreAsync()
         {
             if (storeManager == null)
                 storeManager = ServiceLocator.Instance.Resolve<IStoreManager>();
 
             if (!storeManager.IsInitialized)
-                await storeManager.InitializeAsync().ConfigureAwait(false);
+                await storeManager.InitializeAsync();
         }
 
         public virtual async Task<IEnumerable<T>> GetItemsAsync(int skip = 0, int take = 100, bool forceRefresh = false)
         {
-            await InitializeStoreAsync().ConfigureAwait(false);
+            await InitializeStoreAsync();
             if (forceRefresh)
             {
-                await SyncAsync().ConfigureAwait(false);
+                await SyncAsync();
             }
 
-            return await Table.ToEnumerableAsync().ConfigureAwait(false);
+            return await Table.ToEnumerableAsync();
         }
 
         public virtual async Task<T> GetItemAsync(string id)
         {
-            await InitializeStoreAsync().ConfigureAwait(false);
-            await PullLatestAsync().ConfigureAwait(false);
-            var item = await Table.LookupAsync(id).ConfigureAwait(false);
+            await InitializeStoreAsync();
+            await SyncAsync();
+            var item = await Table.LookupAsync(id);
             return item;
         }
 
         public virtual async Task<bool> InsertAsync(T item)
         {
-            await InitializeStoreAsync().ConfigureAwait(false);
-
-            await Table.InsertAsync(item).ConfigureAwait(false);
-            await SyncAsync();
+            await InitializeStoreAsync();
+            await Table.InsertAsync(item); //Insert into the local store
+            await SyncAsync(); //Send changes to the mobile service
             return true;
         }
 
         public virtual async Task<bool> UpdateAsync(T item)
         {
-            await InitializeStoreAsync().ConfigureAwait(false);
-            await Table.UpdateAsync(item).ConfigureAwait(false);
-            await SyncAsync().ConfigureAwait(false);
+            await InitializeStoreAsync();
+            await Table.UpdateAsync(item); //Delete from the local store
+            await SyncAsync(); //Send changes to the mobile service
             return true;
         }
 
@@ -95,10 +94,9 @@ namespace MyDriving.DataStore.Azure.Stores
             bool result = false;
             try
             {
-                await InitializeStoreAsync().ConfigureAwait(false);
-                await PullLatestAsync().ConfigureAwait(false);
-                await Table.DeleteAsync(item).ConfigureAwait(false);
-                await SyncAsync().ConfigureAwait(false);
+                await InitializeStoreAsync();
+                await Table.DeleteAsync(item); //Delete from the local store
+                await SyncAsync(); //Send changes to the mobile service
                 result = true;
             }
             catch (Exception e)
@@ -109,26 +107,10 @@ namespace MyDriving.DataStore.Azure.Stores
             return result;
         }
 
-        public virtual async Task<bool> PullLatestAsync()
-        {
-            if (!CrossConnectivity.Current.IsConnected)
-            {
-                Logger.Instance.Track("Unable to pull items, we are offline");
-                return false;
-            }
-            try
-            {
-                await Table.PullAsync($"all{Identifier}", Table.CreateQuery()).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Logger.Instance.Track("PullLatestAsync: Unable to pull items: " + ex.Message);
-                return false;
-            }
-            return true;
-        }
-
-
+        //Note: do not call SyncAsync with ConfigureAwait(false) because when the authentication token expires,
+        //the thread running this method needs to open the Login UI.
+        //Also in the method which calls SyncAsync, do not use ConfigureAwait(false) before calling SyncAsync, because once ConfigureAwait(false) is used
+        //in the context of an async method, the rest of that method's code may also run on a background thread.
         public virtual async Task<bool> SyncAsync()
         {
             if (!CrossConnectivity.Current.IsConnected)
@@ -138,22 +120,23 @@ namespace MyDriving.DataStore.Azure.Stores
             }
             try
             {
-                var client = ServiceLocator.Instance.Resolve<IAzureClient>()?.Client;
+                var client = ServiceLocator.Instance.Resolve<IAzureClient>()?.Client; 
                 if (client == null)
                 {
                     Logger.Instance.Track("Unable to sync items, client is null");
 
                     return false;
                 }
-                await PullLatestAsync().ConfigureAwait(false);
-                await client.SyncContext.PushAsync().ConfigureAwait(false);
+
+                //push changes on the sync context before pulling new items
+                await client.SyncContext.PushAsync();
+                await Table.PullAsync($"all{Identifier}", Table.CreateQuery());
             }
             catch (Exception ex)
             {
-                Logger.Instance.Track("SyncAsync: Unable to sync items: " + ex.Message);
+                Logger.Instance.Track("SyncAsync: Unable to push/pull items: " + ex.Message);
                 return false;
             }
-
             return true;
         }
 

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/IOTHubStore.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/IOTHubStore.cs
@@ -11,11 +11,6 @@ namespace MyDriving.DataStore.Azure.Stores
     {
         public override string Identifier => "IOTHub";
 
-        public override Task<bool> PullLatestAsync()
-        {
-            return Task.FromResult(true);
-        }
-
         public override Task<bool> SyncAsync()
         {
             return Task.FromResult(true);

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/POIStore.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/POIStore.cs
@@ -14,9 +14,9 @@ namespace MyDriving.DataStore.Azure.Stores
         public async Task<IEnumerable<POI>> GetItemsAsync(string tripId)
         {
             //Always force refresh
-            await InitializeStoreAsync().ConfigureAwait(false);
-            await SyncAsync().ConfigureAwait(false);
-            return await Table.CreateQuery().Where(p => p.TripId == tripId).ToEnumerableAsync().ConfigureAwait(false);
+            await InitializeStoreAsync();
+            await SyncAsync();
+            return await Table.CreateQuery().Where(p => p.TripId == tripId).ToEnumerableAsync();
         }
     }
 }

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/PhotoStore.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/PhotoStore.cs
@@ -12,11 +12,6 @@ namespace MyDriving.DataStore.Azure.Stores
     {
         public override string Identifier => "Photo";
 
-        public override Task<bool> PullLatestAsync()
-        {
-            return Task.FromResult(true);
-        }
-
         public override Task<bool> SyncAsync()
         {
             return Task.FromResult(true);

--- a/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/TripPointStore.cs
+++ b/src/MobileApps/MyDriving/MyDriving.DataStore.Azure/Stores/TripPointStore.cs
@@ -18,16 +18,16 @@ namespace MyDriving.DataStore.Azure.Stores
 
         public override async Task<bool> InsertAsync(TripPoint item)
         {
-            await Table.InsertAsync(item).ConfigureAwait(false);
+            await Table.InsertAsync(item);
             return true;
         }
 
         public async Task<IEnumerable<TripPoint>> GetPointsForTripAsync(string id)
         {
-            await InitializeStoreAsync().ConfigureAwait(false);
+            await InitializeStoreAsync();
 
             //first look locally for points.
-            var points = await Table.Where(s => s.TripId == id).OrderBy(p => p.Sequence).ToEnumerableAsync().ConfigureAwait(false);
+            var points = await Table.Where(s => s.TripId == id).OrderBy(p => p.Sequence).ToEnumerableAsync();
 
             if (points.Any())
                 return points;
@@ -44,7 +44,7 @@ namespace MyDriving.DataStore.Azure.Stores
             {
                 //await SyncAsync();
                 var pullId = $"{id}";
-                await Table.PullAsync(pullId, Table.Where(s => s.TripId == id)).ConfigureAwait(false);
+                await Table.PullAsync(pullId, Table.Where(s => s.TripId == id));
 
             }
             catch (Exception ex)
@@ -52,7 +52,7 @@ namespace MyDriving.DataStore.Azure.Stores
                 Logger.Instance.Track("TripPointStore: Unable to pull items: " + ex.Message);
             }
 
-            return await Table.Where(s => s.TripId == id).OrderBy(p => p.Sequence).ToEnumerableAsync().ConfigureAwait(false);
+            return await Table.Where(s => s.TripId == id).OrderBy(p => p.Sequence).ToEnumerableAsync();
         }
 
         public override async Task<bool> SyncAsync()
@@ -65,7 +65,7 @@ namespace MyDriving.DataStore.Azure.Stores
             try
             {
                 var client = ServiceLocator.Instance.Resolve<IAzureClient>()?.Client;
-                await client.SyncContext.PushAsync().ConfigureAwait(false);
+                await client.SyncContext.PushAsync();
             }
             catch (Exception ex)
             {

--- a/src/MobileApps/MyDriving/MyDriving.UWP/App.xaml.cs
+++ b/src/MobileApps/MyDriving/MyDriving.UWP/App.xaml.cs
@@ -12,7 +12,7 @@ using MyDriving.Shared;
 using MyDriving.Utils;
 using MyDriving.UWP.Helpers;
 using MyDriving.UWP.Views;
-using MyDriving.UWP.Controls;
+using MyDriving.Utils.Interfaces;
 
 namespace MyDriving.UWP
 {

--- a/src/MobileApps/MyDriving/MyDriving.UWP/Helpers/Authentication.cs
+++ b/src/MobileApps/MyDriving/MyDriving.UWP/Helpers/Authentication.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.MobileServices;
-using MyDriving.Interfaces;
 using MyDriving.Utils;
+using MyDriving.Utils.Interfaces;
+using Windows.UI.Core;
 
 namespace MyDriving.UWP.Helpers
 {
@@ -18,14 +21,34 @@ namespace MyDriving.UWP.Helpers
         public async Task<MobileServiceUser> LoginAsync(IMobileServiceClient client,
             MobileServiceAuthenticationProvider provider)
         {
+            var coreWindow = Windows.ApplicationModel.Core.CoreApplication.MainView;
+            // Dispatcher needed to run on UI Thread
+            var dispatcher = coreWindow.CoreWindow.Dispatcher;
+
+            MobileServiceUser user = null;
+
+
             try
             {
-                var user = await client.LoginAsync(provider);
+                if (dispatcher.HasThreadAccess)  //is running on UI thread
+                {
+                    user = await client.LoginAsync(provider);
+                }
+                else
+                {
+                    await dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+                    {
+                        user = await client.LoginAsync(provider);
 
-                Settings.Current.AuthToken = user?.MobileServiceAuthenticationToken ?? string.Empty;
-                Settings.Current.AzureMobileUserId = user?.UserId ?? string.Empty;
+                    });
+                }
 
-                return user;
+                if (user != null)
+                {
+                    Settings.Current.AuthToken = user?.MobileServiceAuthenticationToken ?? string.Empty;
+                    Settings.Current.AzureMobileUserId = user?.UserId ?? string.Empty;
+                }
+
             }
             catch (Exception e)
             {
@@ -36,7 +59,8 @@ namespace MyDriving.UWP.Helpers
                 }
             }
 
-            return null;
+            return user;
         }
+
     }
 }

--- a/src/MobileApps/MyDriving/MyDriving.Utils/Helpers/ProgressDialogManager.cs
+++ b/src/MobileApps/MyDriving/MyDriving.Utils/Helpers/ProgressDialogManager.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyDriving.Utils.Helpers
+{
+    public static class ProgressDialogManager
+    {
+        private static Acr.UserDialogs.IProgressDialog currentProgressDialog;
+
+        public static void LoadProgressDialog(string title)
+        {
+            currentProgressDialog = Acr.UserDialogs.UserDialogs.Instance.Loading(title, maskType: Acr.UserDialogs.MaskType.Clear);
+        }
+
+        public static void HideProgressDialog()
+        {
+            currentProgressDialog?.Hide();
+        }
+
+        public static void ShowProgressDialog()
+        {
+            currentProgressDialog?.Show();
+        }
+
+        public static void DisposeProgressDialog()
+        {
+            currentProgressDialog?.Dispose();
+            currentProgressDialog = null;
+        }
+    }
+}

--- a/src/MobileApps/MyDriving/MyDriving.Utils/Interfaces/IAuthentication.cs
+++ b/src/MobileApps/MyDriving/MyDriving.Utils/Interfaces/IAuthentication.cs
@@ -2,13 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Microsoft.WindowsAzure.MobileServices;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
-namespace MyDriving.Interfaces
+namespace MyDriving.Utils.Interfaces
 {
     public interface IAuthentication
     {
         Task<MobileServiceUser> LoginAsync(IMobileServiceClient client, MobileServiceAuthenticationProvider provider);
+
         void ClearCookies();
     }
 }

--- a/src/MobileApps/MyDriving/MyDriving.Utils/MyDriving.Utils.csproj
+++ b/src/MobileApps/MyDriving/MyDriving.Utils/MyDriving.Utils.csproj
@@ -10,6 +10,8 @@
     <AssemblyName>MyDriving.Utils</AssemblyName>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +40,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Helpers\ProgressDialogManager.cs" />
+    <Compile Include="Interfaces\IAuthentication.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceLocator.cs" />
     <Compile Include="Interfaces\ILogger.cs" />
@@ -48,14 +52,52 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup />
   <ItemGroup>
+    <Reference Include="Acr.UserDialogs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Acr.UserDialogs.5.2.0-beta1\lib\portable-win+net45+wp8+win8+wpa81\Acr.UserDialogs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Acr.UserDialogs.Interface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Acr.UserDialogs.5.2.0-beta1\lib\portable-win+net45+wp8+win8+wpa81\Acr.UserDialogs.Interface.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Mobile.Client.2.0.1\lib\portable-win+net45+wp8+wpa81+monotouch+monoandroid\Microsoft.WindowsAzure.Mobile.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Plugin.Settings">
       <HintPath>..\..\packages\Xam.Plugins.Settings.2.1.0\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.Settings.dll</HintPath>
     </Reference>
     <Reference Include="Plugin.Settings.Abstractions">
       <HintPath>..\..\packages\Xam.Plugins.Settings.2.1.0\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.Settings.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Splat.1.6.2\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net45+win8\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net45+win8\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
 </Project>

--- a/src/MobileApps/MyDriving/MyDriving.Utils/app.config
+++ b/src/MobileApps/MyDriving/MyDriving.Utils/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/MobileApps/MyDriving/MyDriving.Utils/packages.config
+++ b/src/MobileApps/MyDriving/MyDriving.Utils/packages.config
@@ -1,4 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Acr.UserDialogs" version="5.2.0-beta1" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable45-net45+win8" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable45-net45+win8" />
+  <package id="Splat" version="1.6.2" targetFramework="portable45-net45+win8" />
   <package id="Xam.Plugins.Settings" version="2.1.0" targetFramework="portable-net45+win+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
 </packages>

--- a/src/MobileApps/MyDriving/MyDriving.iOS/MyDriving.iOS.csproj
+++ b/src/MobileApps/MyDriving/MyDriving.iOS/MyDriving.iOS.csproj
@@ -127,6 +127,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
@@ -256,6 +257,10 @@
       <Name>ObdLibiOS</Name>
       <IsAppExtension>False</IsAppExtension>
       <IsWatchApp>False</IsWatchApp>
+    </ProjectReference>
+    <ProjectReference Include="..\MyDriving.AzureClient\MyDriving.AzureClient.csproj">
+      <Project>{29B6B823-6639-4942-9723-0075BBEF7C69}</Project>
+      <Name>MyDriving.AzureClient</Name>
     </ProjectReference>
     <ProjectReference Include="..\MyDriving.DataStore.Abstractions\MyDriving.DataStore.Abstractions.csproj">
       <Project>{649300CE-70EA-4606-983F-F4476FDD6C7E}</Project>

--- a/src/MobileApps/MyDriving/MyDriving.iOS/Screens/Trips/CurrentTripViewController.cs
+++ b/src/MobileApps/MyDriving/MyDriving.iOS/Screens/Trips/CurrentTripViewController.cs
@@ -14,6 +14,10 @@ using MyDriving.DataObjects;
 using MyDriving.ViewModel;
 using Plugin.Permissions;
 using Plugin.Permissions.Abstractions;
+using MyDriving.Utils;
+using Microsoft.WindowsAzure.MobileServices;
+using MyDriving.iOS.Helpers;
+using MyDriving.AzureClient;
 
 namespace MyDriving.iOS
 {
@@ -49,7 +53,7 @@ namespace MyDriving.iOS
 
 			if (CurrentTripViewModel != null)
 			{
-				await CurrentTripViewModel.ExecuteStartTrackingTripCommandAsync().ContinueWith(async (task) =>
+                await CurrentTripViewModel.ExecuteStartTrackingTripCommandAsync().ContinueWith(async (task) =>
 				{
 					// If we don't have permission from the user, prompt a dialog requesting permission.
 					await PromptPermissionsChangeDialog();
@@ -92,6 +96,7 @@ namespace MyDriving.iOS
 
             CurrentTripViewModel = new CurrentTripViewModel();
             CurrentTripViewModel.Geolocator.PositionChanged += Geolocator_PositionChanged;
+                 
         }
 
         void AnimateTripInfoView()

--- a/src/MobileApps/MyDriving/MyDriving/MyDriving.csproj
+++ b/src/MobileApps/MyDriving/MyDriving/MyDriving.csproj
@@ -56,7 +56,6 @@
     <Compile Include="ViewModel\SettingsViewModel.cs" />
     <Compile Include="ViewModel\TripSummaryViewModel.cs" />
     <Compile Include="ViewModel\ViewModelBase.cs" />
-    <Compile Include="Interfaces\IAuthentication.cs" />
     <Compile Include="ViewModel\PastTripsDetailViewModel.cs" />
     <Compile Include="Helpers\UserProfile.cs" />
     <Compile Include="Interfaces\IGeocoder.cs" />

--- a/src/MobileApps/MyDriving/MyDriving/ViewModel/LoginViewModel.cs
+++ b/src/MobileApps/MyDriving/MyDriving/ViewModel/LoginViewModel.cs
@@ -5,11 +5,11 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using MyDriving.Utils;
 using MyDriving.Helpers;
-using MyDriving.Interfaces;
 using MyDriving.DataObjects;
 using Microsoft.WindowsAzure.MobileServices;
 using MyDriving.AzureClient;
 using System;
+using MyDriving.Utils.Interfaces;
 
 namespace MyDriving.ViewModel
 {

--- a/src/MobileApps/MyDriving/MyDriving/ViewModel/PastTripsDetailViewModel.cs
+++ b/src/MobileApps/MyDriving/MyDriving/ViewModel/PastTripsDetailViewModel.cs
@@ -9,6 +9,7 @@ using MyDriving.Helpers;
 using MyDriving.Utils;
 using MyDriving.DataObjects;
 using System.Collections.Generic;
+using MyDriving.Utils.Helpers;
 
 namespace MyDriving.ViewModel
 {
@@ -110,8 +111,7 @@ namespace MyDriving.ViewModel
             if (IsBusy)
                 return false;
 
-            var progress = Acr.UserDialogs.UserDialogs.Instance.Loading("Loading trip details...",
-                maskType: Acr.UserDialogs.MaskType.Clear);
+            ProgressDialogManager.LoadProgressDialog("Loading trip details...");
 
             bool error = false;
             string errorMessage = "Please check internet connection and try again.";
@@ -160,7 +160,7 @@ namespace MyDriving.ViewModel
             }
             finally
             {
-                progress?.Dispose();
+                ProgressDialogManager.DisposeProgressDialog();
                 IsBusy = false;
             }
 

--- a/src/MobileApps/MyDriving/MyDriving/ViewModel/PastTripsViewModel.cs
+++ b/src/MobileApps/MyDriving/MyDriving/ViewModel/PastTripsViewModel.cs
@@ -9,6 +9,7 @@ using MyDriving.Helpers;
 using MyDriving.Utils;
 using Acr.UserDialogs;
 using MvvmHelpers;
+using MyDriving.Utils.Helpers;
 
 namespace MyDriving.ViewModel
 {
@@ -50,7 +51,6 @@ namespace MyDriving.ViewModel
                 await StoreManager.TripStore.RemoveAsync(trip);
 
                 Trips.Remove(trip);
-                Settings.Logout();
             }
             catch (Exception ex)
             {
@@ -61,7 +61,6 @@ namespace MyDriving.ViewModel
                 progress?.Dispose();
             }
 
-
             return true;
         }
 
@@ -70,7 +69,7 @@ namespace MyDriving.ViewModel
             if (IsBusy)
                 return;
 
-            var progressDialog = UserDialogs.Instance.Loading("Loading trips...", maskType: MaskType.Clear);
+            ProgressDialogManager.LoadProgressDialog("Loading trips...");
 
             try
             {
@@ -92,7 +91,7 @@ namespace MyDriving.ViewModel
             {
                 IsBusy = false;
 
-                progressDialog?.Dispose();
+                ProgressDialogManager.DisposeProgressDialog();
             }
 
             if (Trips.Count == 0)
@@ -110,7 +109,7 @@ namespace MyDriving.ViewModel
 
             var track = Logger.Instance.TrackTime("LoadMoreTrips");
             track?.Start();
-            var progress = UserDialogs.Instance.Loading("Loading more trips...", maskType: MaskType.Clear);
+            ProgressDialogManager.LoadProgressDialog("Loading more trips...");
 
             try
             {
@@ -130,7 +129,7 @@ namespace MyDriving.ViewModel
             {
                 track?.Stop();
                 IsBusy = false;
-                progress?.Dispose();
+                ProgressDialogManager.DisposeProgressDialog();
             }
         }
     }

--- a/src/MobileApps/MyDriving/MyDriving/ViewModel/ProfileViewModel.cs
+++ b/src/MobileApps/MyDriving/MyDriving/ViewModel/ProfileViewModel.cs
@@ -7,6 +7,7 @@ using MyDriving.Utils;
 using System.Threading.Tasks;
 using System.Linq;
 using System;
+using MyDriving.Utils.Helpers;
 
 namespace MyDriving.ViewModel
 {
@@ -174,8 +175,8 @@ namespace MyDriving.ViewModel
             if (IsBusy)
                 return false;
 
-            var progress = Acr.UserDialogs.UserDialogs.Instance.Loading("Loading profile...",
-                maskType: Acr.UserDialogs.MaskType.Clear);
+            ProgressDialogManager.LoadProgressDialog("Loading profile...");
+
             var error = false;
             try
             {
@@ -217,7 +218,7 @@ namespace MyDriving.ViewModel
             }
             finally
             {
-                progress?.Dispose();
+                ProgressDialogManager.DisposeProgressDialog();
                 IsBusy = false;
             }
 


### PR DESCRIPTION
## Solution
To fix issue #548 in the MyDriving app, there are two sets of changes that should be considered to truly round-out the overall user experience when dealing with authentication:
•	Critical changes that must be fixed so that the app remains functional when a user’s access token expires or is invalid; these changes will be fixed now as part of the check-in for this issue
•	User experience enhancements; these changes aren’t feasible to fix at this point in time, but will be discussed below since they ideally should have been considered as part of the app’s upfront design

## Critical fixes
1.)	**Use custom auth handler pattern for refreshing expired/invalid access tokens**
A recommended pattern is to use a custom auth handler to intercept requests to the mobile service and check whether an Unauthorized response is received.  When an Unauthorized response is received, the handler attempts to refresh the access token.  If refreshing the token fails, the handler displays the login screen to prompt the user to log back in.  
As part of this change to the MyDriving app, the code was updated to:
a.	Call the mobile service’s “.auth/refresh” endpoint to refresh the access token.
b.	Call a platform specific version of the SDK’s LoginAsync method that displays a login screen within the context of the iOS/Android/UWP apps. 
c.	Resend the request to the mobile service once a valid access token is obtained.  If a valid access token isn’t obtained, then the request fails because the user can’t be authenticated.  In this case, the app will continue to run by reading/saving to the local data store on the device.  Eventually, when the user successfully logs back in, the app will reconnect to the mobile service and push/pull changes to/from the backend server.  
You’ll notice that the app only attempts to refresh the token for MSA which is because the access token expires in only 1 hour.  For Facebook and Twitter, refreshing the token isn’t needed since:
•	Facebook uses a “long-lived” token that expires after 60 days.  The token is refreshed automatically when the user is redirected to the login screen and then the user is automatically brought back to the app without having to login again.
•	Twitter access tokens never expire.
It’s also important to note that refreshing a token doesn’t always work.  For example, the user may have changed their password.  Also, there is a 72-hour timeframe after the access token is expired/invalid that you must refresh the token within.  If this timeframe is exceeded, refreshing the token fails and the app must prompt the user to re-login.

2.)	**Preemptively check for authentication when first screen is opened**
A benefit of using the custom auth handler pattern is that it checks all requests to the mobile service for an Unauthorized response and prompts the user to login as needed – this is important since an access token can be invalidated by the provider at any time.  The downside, is that since the login screen may be displayed in the middle of any request, this can potentially disrupt user workflows within the app.
To increase the likelihood that the user is authenticated prior to entering common workflows within the app, the app now preemptively checks that the user is authenticated within the first screen that is opened – specifically, in the Current Trip screen.  To do this, the code makes a benign request to the mobile service’s “.auth/me” endpoint in attempt to get the authenticated user’s info.  If this request fails due to an Unauthorized response, the custom auth handler gets a refreshed token and prompts the user to login if needed.

3.)	**Remove calls to ConfigureAwait(false)**
The MyDriving app frequently called ConfigureAwait(false) when pushing/pulling changes to/from the backend server.  These calls were originally put in as a potential optimization; however, this introduced complexity in the app because if a push/pull request failed due to the user being unauthenticated, the app needed to potentially switch back to the main UI thread in order to display the login screen.  To simplify this, the calls to ConfigureAwait(false) were removed and as a result, the code that displays the login screen now runs on the main UI thread.

## User experience enhancements
1.)	**Improve the app’s UX to indicate to the user when it is disconnected from the mobile service and provide explicit syncing**
The MyDriving app can become disconnected from the mobile service in two situations:
a.	There is no network connection
b.	The user has become unauthenticated (e.g. their access token is expired or invalid)
In both of these situations, the MyDriving app uses Azure Mobile Apps offline data sync feature to save the data locally to the device and then push the data to the backend server when the app is able to reconnect to the mobile service.  Similarly, the app reads data that is cached locally on the device and then pulls refreshed data from the backend server when the app is able to reconnect.  
Today, the MyDriving app does not indicate to the user when it has become disconnected from the mobile service.  This can be misleading to the user, especially in the case where there is network connection, but the user isn’t authenticated and as a result, data is being read/saved locally only.  Ideally, the app should:
•	Provide a message or some other indicator in the UX that clearly shows when the app is running offline due to lack of network connection or due to being unauthenticated.
•	Provide a “sync” button in within the UX that allows the user to explicitly refresh cached data and push data to the backend service.

This issue underscores the importance of thinking about authentication upfront when designing an app.

## References
For more information on what was discussed above, refer to the following resources:
•	[Authentication and authorization in azure app service](https://azure.microsoft.com/en-us/documentation/articles/app-service-authentication-overview/)
•	[Caching and handling expired tokens in Azure Mobile Services managed SDK](https://blogs.msdn.microsoft.com/carlosfigueira/2014/03/12/caching-and-handling-expired-tokens-in-azure-mobile-services-managed-sdk/)
•	[App Service Token Store](https://cgillum.tech/2016/03/07/app-service-token-store/)
•	[Async/Await – Best Practices in Asynchronous Programming](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx) (includes best practices on ConfigureAwait(false))

