### PR TITLE
[android] fix a tiny mistake in styles.xml

### DIFF
--- a/src/MobileApps/MyDriving/MyDriving.Android/Resources/values/styles.xml
+++ b/src/MobileApps/MyDriving/MyDriving.Android/Resources/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="colorAccent">@color/accent</item>
     </style>
 
-    <style name="MyThemeDark.ActionBar" parent="style/Widget.AppCompat.ActionBar.Solid">
+    <style name="MyThemeDark.ActionBar" parent="Widget.AppCompat.ActionBar.Solid">
         <!-- remove shadow below action bar -->
         <!-- <item name="android:elevation">0dp</item> -->
         <!-- Support library compatibility -->
@@ -66,7 +66,7 @@
 		  <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
-    <style name="MyTheme.ActionBar" parent="style/Widget.AppCompat.Light.ActionBar.Solid">
+    <style name="MyTheme.ActionBar" parent="Widget.AppCompat.Light.ActionBar.Solid">
         <!-- remove shadow below action bar -->
         <!-- <item name="android:elevation">0dp</item> -->
         <!-- Support library compatibility -->


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2657

We have some regression tests that build this app with Xamarin.Android.

We discovered a new feature `$(AndroidUseAapt2)` was triggering this app to fail to build. Luckily there is just a tiny mistake here, which `aapt` ignored and `aapt2` reported as an error.